### PR TITLE
Update libxmljs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"There are no tests! Someone should totally write some. That would be awesome.\" && exit 1"
   },
   "dependencies": {
-    "libxmljs": "~0.6.1"
+    "libxmljs": "~0.8.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The node-open311 project failed to install with newer node.js (0.10.3) because it depends on this project, and the older libxmljs here doesn't work with the newer node. Or that's what I think happened.
