### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "6"
+  - "5"
+  - "4"
+  - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,17 @@ node_js:
   - "5"
   - "4"
   - "0.12"
+
+# a compiler must be installed for libxmljs
+# https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
+compiler: clang-3.6
+env:
+  - CXX=clang-3.6
+addons:
+  apt:
+    sources:
+      - llvm-toolchain-precise-3.6
+      - ubuntu-toolchain-r-test
+    packages:
+      - clang-3.6
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ node_js:
 
 # a compiler must be installed for libxmljs
 # https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
-compiler: clang-3.6
 env:
-  - CXX=clang-3.6
+  - CXX=g++-4.8
 addons:
   apt:
     sources:
-      - llvm-toolchain-precise-3.6
       - ubuntu-toolchain-r-test
     packages:
-      - clang-3.6
       - g++-4.8


### PR DESCRIPTION
Now that tests are merged in, there should really be CI.

(Note tests on newer Node.js versions will fail until #10 is merged.)